### PR TITLE
Find non-matching parallax and diffuse textures

### DIFF
--- a/ParallaxGen/src/main.cpp
+++ b/ParallaxGen/src/main.cpp
@@ -268,9 +268,9 @@ void mainRunner(ParallaxGenCLIArgs &Args, const filesystem::path &ExePath) {
   if (!NonMatchingMods.empty()) {
     spdlog::warn(
         "There are parallax textures from different mods than their corresponding diffuse textures. This will "
-        "cause visual problems if the textures don't match. Run with --vv to get a list of all textures in the logs.");
+        "cause visual problems if the textures don't match. Run with -v to get a list of all textures in the logs.");
     for (auto &const Pair : NonMatchingMods) {
-      spdlog::warn(L"{} ---> {}", Pair.first, Pair.second);
+      spdlog::warn(L"Potential texture mismatch {} ---> {}", Pair.first, Pair.second);
     }
   }
 

--- a/ParallaxGenLib/CMakeLists.txt
+++ b/ParallaxGenLib/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(HEADERS
     "include/BethesdaGame.hpp"
     "include/BethesdaDirectory.hpp"
+    "include/ModManagerDirectory.hpp"
     "include/NIFUtil.hpp"
     "include/ParallaxGen.hpp"
     "include/ParallaxGenConfig.hpp"
@@ -18,6 +19,7 @@ set(HEADERS
 set(SOURCES
     "src/BethesdaGame.cpp"
     "src/BethesdaDirectory.cpp"
+    "src/ModManagerDirectory.cpp"
     "src/NIFUtil.cpp"
     "src/ParallaxGen.cpp"
     "src/ParallaxGenConfig.cpp"

--- a/ParallaxGenLib/include/BethesdaDirectory.hpp
+++ b/ParallaxGenLib/include/BethesdaDirectory.hpp
@@ -156,7 +156,7 @@ public:
    * @param RelPath path to the file relative to the data directory
    * @return std::filesystem::path absolute path to the file
    */
-  [[nodiscard]] auto getFullPath(const std::filesystem::path &RelPath) const -> std::filesystem::path;
+  [[nodiscard]] auto getLooseFileFullPath(const std::filesystem::path &RelPath) const -> std::filesystem::path;
 
   /**
    * @brief Find files in the load order

--- a/ParallaxGenLib/include/ModManagerDirectory.hpp
+++ b/ParallaxGenLib/include/ModManagerDirectory.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <boost/crc.hpp>
+#include <boost/functional/hash.hpp>
+
+#include <filesystem>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+class ModManagerDirectory {
+public:
+  struct TextureEntry {
+    std::filesystem::path Path{};
+    uintmax_t FileSize{};
+
+    auto operator==(const TextureEntry &Other) const -> bool {
+      return Path == Other.Path && FileSize == Other.FileSize;
+    }
+  };
+
+  struct TextureEntryHasher {
+    auto operator()(const TextureEntry &Texture) const -> size_t {
+      std::size_t Hash = std::hash<std::filesystem::path>()(Texture.Path);
+      boost::hash_combine(Hash, Texture.FileSize);
+      return Hash;
+    }
+  };
+
+private:
+  auto FindModPath(TextureEntry const &TextureToCompare) const -> std::filesystem::path;
+  std::filesystem::path StagingDir;
+  // vector is slightly faster than unordered_set, probably due to hash function of Path
+  std::vector<TextureEntry> Textures;
+
+public:
+  ModManagerDirectory(std::filesystem::path const &StagingDir);
+
+  /// @brief find all textures in the mod staging folder and store them internally for further processing
+  auto FindTextureFilesInDir() -> void;
+
+  /// @brief Find the texture in the mod directories
+  /// @param TextureToCompare full path of the texture
+  /// @return full path of the mod the texture in mod directories
+  auto FindModPath(std::filesystem::path const &TextureToCompare) const -> std::filesystem::path;
+
+  /// @brief deduct the mod name from the texture path
+  /// @param full path of the texture
+  /// @return mod name
+  static auto GetModFromTexture(std::filesystem::path) -> std::wstring;
+};

--- a/ParallaxGenLib/include/ParallaxGenDirectory.hpp
+++ b/ParallaxGenLib/include/ParallaxGenDirectory.hpp
@@ -16,6 +16,8 @@
 #include "NIFUtil.hpp"
 #include "ParallaxGenTask.hpp"
 
+class ModManagerDirectory;
+
 #define MAPTEXTURE_PROGRESS_MODULO 10
 
 class ParallaxGenDirectory : public BethesdaDirectory {
@@ -106,4 +108,10 @@ public:
   [[nodiscard]] auto getPBRJSONs() const -> const std::vector<std::filesystem::path> &;
 
   [[nodiscard]] auto getPGJSONs() const -> const std::vector<std::filesystem::path> &;
+
+  /// @brief Find diffuse and parallax textures from different mods
+  /// @param MD Must be initialized @see ModManagerDirectory::FindTextureFilesInDir
+  /// @return set of mods that contain non-matching textures
+  [[nodiscard]] auto FindNonMatchingDiffuseParallax(const ModManagerDirectory &MD)
+      -> std::set<std::pair<std::wstring, std::wstring>>;
 };

--- a/ParallaxGenLib/src/BethesdaDirectory.cpp
+++ b/ParallaxGenLib/src/BethesdaDirectory.cpp
@@ -229,7 +229,7 @@ auto BethesdaDirectory::isPrefix(const filesystem::path &RelPath) const -> bool 
          (It != FileMap.begin() && boost::istarts_with(prev(It)->first.wstring(), RelPath.wstring()));
 }
 
-auto BethesdaDirectory::getFullPath(const filesystem::path &RelPath) const -> filesystem::path {
+auto BethesdaDirectory::getLooseFileFullPath(const filesystem::path &RelPath) const -> filesystem::path {
   return DataDir / RelPath;
 }
 

--- a/ParallaxGenLib/src/ModManagerDirectory.cpp
+++ b/ParallaxGenLib/src/ModManagerDirectory.cpp
@@ -1,0 +1,64 @@
+#include "ModManagerDirectory.hpp"
+#include "BethesdaDirectory.hpp"
+#include "ParallaxGenUtil.hpp"
+
+#include <boost/crc.hpp>
+
+#include <filesystem>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+ModManagerDirectory::ModManagerDirectory(std::filesystem::path const &StagingDir) : StagingDir(StagingDir) {}
+
+auto ModManagerDirectory::FindTextureFilesInDir() -> void {
+  std::filesystem::recursive_directory_iterator ModIterator(StagingDir);
+  for (auto &CurItem : ModIterator) {
+    std::filesystem::path Path = CurItem.path();
+    if (std::filesystem::is_regular_file(Path) &&
+        (BethesdaDirectory::pathEqualityIgnoreCase(Path.extension(), std::filesystem::path{L".dds"}))) {
+
+      // note: do not precompute crc32 since it is very expensive
+      Textures.push_back({Path, std::filesystem::file_size(Path)});
+    }
+  }
+}
+
+auto ModManagerDirectory::FindModPath(std::filesystem::path const &TextureToCompare) const -> std::filesystem::path {
+  return FindModPath({TextureToCompare, std::filesystem::file_size(TextureToCompare)});
+}
+
+auto ModManagerDirectory::FindModPath(TextureEntry const &TextureToCompare) const -> std::filesystem::path {
+  for (auto const &Texture : Textures) {
+    if (BethesdaDirectory::pathEqualityIgnoreCase(Texture.Path.filename(), TextureToCompare.Path.filename()) &&
+        (Texture.FileSize == TextureToCompare.FileSize)) {
+
+      boost::crc_32_type CRCTexture;
+      boost::crc_32_type CRCTextureToCompare;
+
+      auto TextureBytes = ParallaxGenUtil::getFileBytes(Texture.Path);
+      auto TextureToCompareBytes = ParallaxGenUtil::getFileBytes(TextureToCompare.Path);
+
+      CRCTexture.process_bytes(TextureBytes.data(), TextureBytes.size());
+      CRCTextureToCompare.process_bytes(TextureToCompareBytes.data(), TextureToCompareBytes.size());
+      if (CRCTexture.checksum() == CRCTextureToCompare.checksum())
+        return Texture.Path;
+    }
+  }
+  return {};
+}
+
+auto ModManagerDirectory::GetModFromTexture(std::filesystem::path TexturePath) -> std::wstring {
+
+  std::filesystem::path ParentPath = TexturePath.parent_path();
+
+  while (!BethesdaDirectory::pathEqualityIgnoreCase(ParentPath.filename(), {L"textures"})) {
+    // no parent anymore
+    if (!ParentPath.has_relative_path())
+      break;
+
+    ParentPath = ParentPath.parent_path();
+  }
+
+  return ParentPath.parent_path().filename().wstring();
+}

--- a/ParallaxGenLib/src/ParallaxGenD3D.cpp
+++ b/ParallaxGenLib/src/ParallaxGenD3D.cpp
@@ -1003,7 +1003,7 @@ auto ParallaxGenD3D::getDDS(const filesystem::path &DDSPath,
 
   if (PGD->isLooseFile(DDSPath)) {
     spdlog::trace(L"Reading DDS loose file {}", DDSPath.wstring());
-    filesystem::path FullPath = PGD->getFullPath(DDSPath);
+    filesystem::path FullPath = PGD->getLooseFileFullPath(DDSPath);
 
     // Load DDS file
     HR = DirectX::LoadFromDDSFile(FullPath.c_str(), DirectX::DDS_FLAGS_NONE, nullptr, DDS);
@@ -1045,7 +1045,7 @@ auto ParallaxGenD3D::getDDSMetadata(const filesystem::path &DDSPath,
 
   if (PGD->isLooseFile(DDSPath)) {
     spdlog::trace(L"Reading DDS loose file metadata {}", DDSPath.wstring());
-    filesystem::path FullPath = PGD->getFullPath(DDSPath);
+    filesystem::path FullPath = PGD->getLooseFileFullPath(DDSPath);
 
     // Load DDS file
     HR = DirectX::GetMetadataFromDDSFile(FullPath.c_str(), DirectX::DDS_FLAGS_NONE, DDSMeta);

--- a/ParallaxGenLib/src/ParallaxGenDirectory.cpp
+++ b/ParallaxGenLib/src/ParallaxGenDirectory.cpp
@@ -464,7 +464,7 @@ auto ParallaxGenDirectory::FindNonMatchingDiffuseParallax(const ModManagerDirect
     if (isLooseFile(DiffuseRelPath)) {
       std::filesystem::path DiffuseFullPath = getLooseFileFullPath(DiffuseRelPath);
       DiffuseModPath = MD.FindModPath(DiffuseFullPath);
-      DiffuseMod = MD.GetModFromTexture(DiffuseModPath);
+      DiffuseMod = ModManagerDirectory::GetModFromTexture(DiffuseModPath);
     } else {
       std::filesystem::path DiffuseBSAPath = FileMap.at(DiffuseRelPath).BSAFile->Path;
       DiffuseMod = DiffuseBSAPath.filename().wstring();
@@ -473,7 +473,7 @@ auto ParallaxGenDirectory::FindNonMatchingDiffuseParallax(const ModManagerDirect
     if (isLooseFile(ParallaxRelPath)) {
       std::filesystem::path ParallaxFullPath = getLooseFileFullPath(ParallaxRelPath);
       ParallaxModPath = MD.FindModPath(ParallaxFullPath);
-      ParallaxMod = MD.GetModFromTexture(ParallaxModPath);
+      ParallaxMod = ModManagerDirectory::GetModFromTexture(ParallaxModPath);
     } else {
       std::filesystem::path ParallaxBSAPath = FileMap.at(ParallaxRelPath).BSAFile->Path;
       ParallaxMod = ParallaxBSAPath.filename().wstring();


### PR DESCRIPTION
Missing TODOs: command line parameter to specify the past and testing with MO2

Filtering of the warnings is not implemented yet I see it as a nice-to-have feature and should probably be implemented in a way that can handle wildcards and both mod names as well as BSAs