### PR TITLE
feat: added search box to mod conflict viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- Added search bar to mod window
 - Confirmation dialog can now be resized freely when a message list is expanded
 - Added `--disable-dyncubemap` CLI argument to tell PGPatcher to never apply dynamic cubemap for Complex Material
 - Added `--ignore-mo2vfscheck` CLI argument to ignore enforcing running under USVFS DLL (For Linux users)

--- a/PGPatcher/include/GUI/ModSortDialog.hpp
+++ b/PGPatcher/include/GUI/ModSortDialog.hpp
@@ -3,9 +3,11 @@
 #include "GUI/components/PGCheckedDragListCtrl.hpp"
 #include "GUI/components/PGCheckedDragListCtrlEvtItemChecked.hpp"
 #include "GUI/components/PGCheckedDragListCtrlEvtItemDragged.hpp"
+#include "GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp"
 #include "PGModManager.hpp"
 #include "pgutil/PGEnums.hpp"
 
+#include <wx/string.h>
 #include <wx/wx.h>
 
 #include <memory>
@@ -25,6 +27,17 @@ private:
     wxButton* m_discardButton = nullptr; /** Discard changes button to revert to last saved state */
     wxButton* m_restoreButton = nullptr; /** Restore default order button */
     wxCheckBox* m_checkBoxMO2 = nullptr; /** Checkbox to use MO2 loose file order */
+    wxTextCtrl* m_searchCtrl = nullptr; /** Search box used to quickly find mods by name */
+
+    struct CachedModRow {
+        std::wstring modName;
+        wxString shaderString;
+        bool isChecked = false;
+        bool areMeshesIgnored = false;
+        bool isNew = false;
+    };
+
+    std::vector<CachedModRow> m_cachedRows; /** Cached full mod list state used for filtering */
 
     std::unordered_set<std::wstring>
         m_newMods; /** Stores the original highlight of elements to be able to restore it later */
@@ -83,6 +96,13 @@ private:
     void onItemChecked(PGCheckedDragListCtrlEvtItemChecked& event);
 
     /**
+     * @brief Event handler that triggers when one or more items are toggled for mesh ignore state
+     *
+     * @param event wxWidgets event object
+     */
+    void onMeshesIgnoredChanged(PGCheckedDragListCtrlEvtMeshesIgnoredChanged& event);
+
+    /**
      * @brief Event handler that triggers when the list control is resized
      *
      * @param event wxWidgets event object
@@ -138,6 +158,13 @@ private:
      */
     void onUseMO2LooseFileOrderChange(wxCommandEvent& event);
 
+    /**
+     * @brief Event handler that triggers when the search text is changed
+     *
+     * @param event wxWidgets event object
+     */
+    void onSearchTextChanged(wxCommandEvent& event);
+
     // Helpers
 
     /**
@@ -177,6 +204,26 @@ private:
     void fillListCtrl(const std::vector<std::shared_ptr<PGModManager::Mod>>& modList,
                       bool autoEnable = false,
                       bool preserveChecks = false);
+
+    /**
+     * @brief Rebuilds the cached rows from the currently visible list control state.
+     */
+    void rebuildCacheFromListCtrl();
+
+    /**
+     * @brief Merges currently visible list state into cache and updates visible-subset ordering.
+     */
+    void syncCacheFromListCtrl();
+
+    /**
+     * @brief Rebuilds the visible list control from cached rows and current search term.
+     */
+    void rebuildListCtrlFromCache();
+
+    /**
+     * @brief Returns trimmed lowercase search text.
+     */
+    [[nodiscard]] auto getActiveSearchTerm() const -> wxString;
 
     /**
      * @brief Enables or disables the apply button based on whether there are unsaved changes

--- a/PGPatcher/include/GUI/ModSortDialog.hpp
+++ b/PGPatcher/include/GUI/ModSortDialog.hpp
@@ -226,6 +226,13 @@ private:
     [[nodiscard]] auto getActiveSearchTerm() const -> wxString;
 
     /**
+     * @brief Returns ordered view of cached rows: enabled rows first, disabled rows second.
+     *
+     * @return Vector of pointers to cached rows in display order.
+     */
+    [[nodiscard]] auto getOrderedCachedRows() const -> std::vector<const CachedModRow*>;
+
+    /**
      * @brief Enables or disables the apply button based on whether there are unsaved changes
      */
     void updateApplyButtonState();

--- a/PGPatcher/include/GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp
+++ b/PGPatcher/include/GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <wx/event.h>
+
+class PGCheckedDragListCtrlEvtMeshesIgnoredChanged;
+wxDECLARE_EVENT(pgEVT_CDLC_MESHES_IGNORED_CHANGED, // NOLINT(readability-identifier-naming)
+                PGCheckedDragListCtrlEvtMeshesIgnoredChanged);
+
+/**
+ * @brief Custom wxCommandEvent fired when one or more items change mesh-ignore state in PGCheckedDragListCtrl.
+ */
+class PGCheckedDragListCtrlEvtMeshesIgnoredChanged : public wxCommandEvent {
+public:
+    /**
+     * @brief Construct a new PGCheckedDragListCtrlEvtMeshesIgnoredChanged event.
+     *
+     * @param id Window or event ID.
+     */
+    explicit PGCheckedDragListCtrlEvtMeshesIgnoredChanged(long id = wxID_ANY)
+        : wxCommandEvent(pgEVT_CDLC_MESHES_IGNORED_CHANGED,
+                         id)
+    {
+    }
+
+    /**
+     * @brief Create a heap-allocated copy of this event (required for wxPostEvent).
+     *
+     * @return Pointer to a cloned copy of this event.
+     */
+    [[nodiscard]] auto Clone() const -> wxEvent* override;
+};

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -725,16 +725,12 @@ void ModSortDialog::syncCacheFromListCtrl()
     std::vector<std::wstring> visibleOrder;
     visibleOrder.reserve(m_listCtrl->GetItemCount());
 
-    std::unordered_set<std::wstring> visibleSet;
-    visibleSet.reserve(m_listCtrl->GetItemCount());
-
     std::unordered_map<std::wstring, CachedModRow> visibleState;
     visibleState.reserve(m_listCtrl->GetItemCount());
 
     for (long i = 0; i < m_listCtrl->GetItemCount(); ++i) {
         const std::wstring modName = m_listCtrl->GetItemText(i, 0).ToStdWstring();
         visibleOrder.push_back(modName);
-        visibleSet.insert(modName);
 
         visibleState[modName] = {.modName = modName,
                                  .shaderString = m_listCtrl->GetItemText(i, 1),
@@ -774,37 +770,8 @@ void ModSortDialog::syncCacheFromListCtrl()
         return;
     }
 
-    // Filtered mode: only reorder visible subset while preserving hidden relative order.
-    std::unordered_map<std::wstring, CachedModRow> rowMap;
-    rowMap.reserve(m_cachedRows.size());
-    for (const auto& row : m_cachedRows) {
-        rowMap[row.modName] = row;
-    }
-
-    size_t insertPos = m_cachedRows.size();
-    for (size_t i = 0; i < m_cachedRows.size(); ++i) {
-        if (visibleSet.contains(m_cachedRows.at(i).modName)) {
-            insertPos = i;
-            break;
-        }
-    }
-
-    std::erase_if(m_cachedRows,
-                  [&visibleSet](const CachedModRow& row) -> bool { return visibleSet.contains(row.modName); });
-
-    insertPos = std::min(insertPos, m_cachedRows.size());
-
-    std::vector<CachedModRow> visibleRows;
-    visibleRows.reserve(visibleOrder.size());
-    for (const auto& modName : visibleOrder) {
-        if (rowMap.contains(modName)) {
-            visibleRows.push_back(rowMap.at(modName));
-        }
-    }
-
-    m_cachedRows.insert(m_cachedRows.begin() + static_cast<std::vector<CachedModRow>::difference_type>(insertPos),
-                        visibleRows.begin(),
-                        visibleRows.end());
+    // Filtered mode: dragging is disabled during search, so the visible order cannot diverge from the
+    // cached order. State has already been merged above; no reordering is needed.
 }
 
 void ModSortDialog::rebuildListCtrlFromCache()

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -265,7 +265,7 @@ void ModSortDialog::onItemDragged(PGCheckedDragListCtrlEvtItemDragged& event)
 void ModSortDialog::onItemChecked(PGCheckedDragListCtrlEvtItemChecked& event)
 {
     // Check if lock mo2 order is on
-    if (m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked() && getActiveSearchTerm().IsEmpty()) {
+    if (m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked()) {
         // Persist the just-updated visible check/ignore state before we rebuild from MO2 order.
         syncCacheFromListCtrl();
 
@@ -515,19 +515,7 @@ void ModSortDialog::updateMods()
     syncCacheFromListCtrl();
 
     // Reconstruct full visual order: enabled rows first, disabled rows second, both stable by cached order.
-    std::vector<const CachedModRow*> orderedRows;
-    orderedRows.reserve(m_cachedRows.size());
-
-    for (const auto& row : m_cachedRows) {
-        if (row.isChecked) {
-            orderedRows.push_back(&row);
-        }
-    }
-    for (const auto& row : m_cachedRows) {
-        if (!row.isChecked) {
-            orderedRows.push_back(&row);
-        }
-    }
+    const auto orderedRows = getOrderedCachedRows();
 
     // Loop through each cached element and update the mod manager directory.
     auto* pgmm = PGGlobals::getPGMM();
@@ -751,8 +739,7 @@ void ModSortDialog::syncCacheFromListCtrl()
         visibleState[modName] = {.modName = modName,
                                  .shaderString = m_listCtrl->GetItemText(i, 1),
                                  .isChecked = m_listCtrl->isChecked(i),
-                                 .areMeshesIgnored = m_listCtrl->areMeshesIgnored(i),
-                                 .isNew = m_newMods.contains(modName)};
+                                 .areMeshesIgnored = m_listCtrl->areMeshesIgnored(i)};
     }
 
     // First, merge visible row state.
@@ -765,7 +752,6 @@ void ModSortDialog::syncCacheFromListCtrl()
         row.shaderString = visibleRow.shaderString;
         row.isChecked = visibleRow.isChecked;
         row.areMeshesIgnored = visibleRow.areMeshesIgnored;
-        row.isNew = visibleRow.isNew;
     }
 
     if (visibleOrder.size() == m_cachedRows.size()) {
@@ -917,13 +903,8 @@ auto ModSortDialog::getActiveSearchTerm() const -> wxString
     return term.Lower();
 }
 
-void ModSortDialog::updateApplyButtonState()
+auto ModSortDialog::getOrderedCachedRows() const -> std::vector<const CachedModRow*>
 {
-    syncCacheFromListCtrl();
-
-    bool btnState = false;
-
-    // Reconstruct full visual order: enabled rows first, disabled rows second, both stable by cached order.
     std::vector<const CachedModRow*> orderedRows;
     orderedRows.reserve(m_cachedRows.size());
 
@@ -937,6 +918,18 @@ void ModSortDialog::updateApplyButtonState()
             orderedRows.push_back(&row);
         }
     }
+
+    return orderedRows;
+}
+
+void ModSortDialog::updateApplyButtonState()
+{
+    syncCacheFromListCtrl();
+
+    bool btnState = false;
+
+    // Reconstruct full visual order: enabled rows first, disabled rows second, both stable by cached order.
+    const auto orderedRows = getOrderedCachedRows();
 
     // Compare cached UI state against PGModManager baseline.
     auto* pgmm = PGGlobals::getPGMM();

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -815,6 +815,7 @@ void ModSortDialog::rebuildListCtrlFromCache()
     }
 
     m_newMods.clear();
+    m_listCtrl->Freeze();
     m_listCtrl->DeleteAllItems();
 
     long index = 0;
@@ -849,6 +850,8 @@ void ModSortDialog::rebuildListCtrlFromCache()
 
         ++index;
     }
+
+    m_listCtrl->Thaw();
 
     const bool mo2Locked = m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked();
     if (m_restoreButton != nullptr) {

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -406,7 +406,6 @@ void ModSortDialog::onSearchTextChanged(wxCommandEvent& event)
 {
     syncCacheFromListCtrl();
     rebuildListCtrlFromCache();
-    updateApplyButtonState();
 
     event.Skip();
 }

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -3,6 +3,7 @@
 #include "GUI/components/PGCheckedDragListCtrl.hpp"
 #include "GUI/components/PGCheckedDragListCtrlEvtItemChecked.hpp"
 #include "GUI/components/PGCheckedDragListCtrlEvtItemDragged.hpp"
+#include "GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp"
 #include "PGConfig.hpp"
 #include "PGGlobals.hpp"
 #include "PGModManager.hpp"
@@ -15,11 +16,14 @@
 #include <wx/wx.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 using namespace std;
@@ -58,6 +62,7 @@ ModSortDialog::ModSortDialog()
 
     m_listCtrl->Bind(pgEVT_CDLC_ITEM_DRAGGED, &ModSortDialog::onItemDragged, this);
     m_listCtrl->Bind(pgEVT_CDLC_ITEM_CHECKED, &ModSortDialog::onItemChecked, this);
+    m_listCtrl->Bind(pgEVT_CDLC_MESHES_IGNORED_CHANGED, &ModSortDialog::onMeshesIgnoredChanged, this);
 
     m_listCtrl->Bind(wxEVT_SIZE, &ModSortDialog::onListCtrlResize, this);
 
@@ -112,6 +117,17 @@ ModSortDialog::ModSortDialog()
         // Add to main sizer
         mainSizer->Add(m_checkBoxMO2, 0, wxALL, DEFAULT_BORDER);
     }
+
+    // Add search box for quick contains-match filtering/selection.
+    auto* searchSizer = new wxBoxSizer(wxHORIZONTAL);
+    auto* searchLabel = new wxStaticText(this, wxID_ANY, "Search:");
+    searchSizer->Add(searchLabel, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, DEFAULT_BORDER);
+
+    m_searchCtrl = new wxTextCtrl(this, wxID_ANY);
+    m_searchCtrl->SetHint("Search mods by name...");
+    m_searchCtrl->Bind(wxEVT_TEXT, &ModSortDialog::onSearchTextChanged, this);
+    searchSizer->Add(m_searchCtrl, 1, wxEXPAND, 0);
+    mainSizer->Add(searchSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, DEFAULT_BORDER);
 
     // FONT for rects
     wxFont rectFont = GetFont(); // start with current font
@@ -208,6 +224,8 @@ ModSortDialog::ModSortDialog()
         m_checkBoxMO2->SetValue(pgc->getParams().ModManager.mo2UseLooseFileOrder);
     }
     setMO2LooseFileOrderCheckboxState();
+    rebuildCacheFromListCtrl();
+    rebuildListCtrlFromCache();
 
     // Calculate minimum width for each column
     const int col1Width = calculateColumnWidth(1);
@@ -239,6 +257,7 @@ void ModSortDialog::onItemDeselected(wxListEvent& event)
 
 void ModSortDialog::onItemDragged(PGCheckedDragListCtrlEvtItemDragged& event)
 {
+    syncCacheFromListCtrl();
     updateApplyButtonState();
     event.Skip();
 }
@@ -246,11 +265,25 @@ void ModSortDialog::onItemDragged(PGCheckedDragListCtrlEvtItemDragged& event)
 void ModSortDialog::onItemChecked(PGCheckedDragListCtrlEvtItemChecked& event)
 {
     // Check if lock mo2 order is on
-    if (m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked()) {
+    if (m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked() && getActiveSearchTerm().IsEmpty()) {
+        // Persist the just-updated visible check/ignore state before we rebuild from MO2 order.
+        syncCacheFromListCtrl();
+
         // reset indices to MO2 state for enabled items
         setMO2LooseFileOrderCheckboxState();
+        rebuildCacheFromListCtrl();
+        rebuildListCtrlFromCache();
+    } else {
+        syncCacheFromListCtrl();
     }
 
+    updateApplyButtonState();
+    event.Skip();
+}
+
+void ModSortDialog::onMeshesIgnoredChanged(PGCheckedDragListCtrlEvtMeshesIgnoredChanged& event)
+{
+    syncCacheFromListCtrl();
     updateApplyButtonState();
     event.Skip();
 }
@@ -298,6 +331,8 @@ void ModSortDialog::onRestoreDefault([[maybe_unused]] wxCommandEvent& event)
     if (response == wxYES) {
         auto* pgmm = PGGlobals::getPGMM();
         fillListCtrl(pgmm->getModsByDefaultOrder(), true);
+        rebuildCacheFromListCtrl();
+        rebuildListCtrlFromCache();
     }
 }
 
@@ -327,12 +362,37 @@ void ModSortDialog::onDiscardChanges([[maybe_unused]] wxCommandEvent& event)
             // Otherwise reset to current priority order
             fillListCtrl(pgmm->getModsByPriority(), false);
         }
+
+        rebuildCacheFromListCtrl();
+        rebuildListCtrlFromCache();
     }
 }
 
 void ModSortDialog::onUseMO2LooseFileOrderChange(wxCommandEvent& event)
 {
+    syncCacheFromListCtrl();
+
+    const bool searchActive = !getActiveSearchTerm().IsEmpty();
+    const bool mo2Locked = (m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked());
+
     setMO2LooseFileOrderCheckboxState();
+
+    // Only rebuild cache directly from the list when the list is full/unfiltered.
+    // Rebuilding from a filtered search view would drop hidden rows and corrupt states.
+    if (!searchActive || mo2Locked) {
+        rebuildCacheFromListCtrl();
+    }
+
+    rebuildListCtrlFromCache();
+    updateApplyButtonState();
+
+    event.Skip();
+}
+
+void ModSortDialog::onSearchTextChanged(wxCommandEvent& event)
+{
+    syncCacheFromListCtrl();
+    rebuildListCtrlFromCache();
     updateApplyButtonState();
 
     event.Skip();
@@ -359,7 +419,8 @@ void ModSortDialog::setMO2LooseFileOrderCheckboxState()
         m_restoreButton->Enable(true);
     }
 
-    m_listCtrl->setDraggingEnabled(!isChecked);
+    const bool searchActive = !getActiveSearchTerm().IsEmpty();
+    m_listCtrl->setDraggingEnabled(!isChecked && !searchActive);
 }
 
 auto ModSortDialog::calculateColumnWidth(int colIndex) -> int
@@ -451,23 +512,40 @@ void ModSortDialog::clearAllHighlights()
 
 void ModSortDialog::updateMods()
 {
-    // loop through each element in the list ctrl and update the mod manager directory
+    syncCacheFromListCtrl();
+
+    // Reconstruct full visual order: enabled rows first, disabled rows second, both stable by cached order.
+    std::vector<const CachedModRow*> orderedRows;
+    orderedRows.reserve(m_cachedRows.size());
+
+    for (const auto& row : m_cachedRows) {
+        if (row.isChecked) {
+            orderedRows.push_back(&row);
+        }
+    }
+    for (const auto& row : m_cachedRows) {
+        if (!row.isChecked) {
+            orderedRows.push_back(&row);
+        }
+    }
+
+    // Loop through each cached element and update the mod manager directory.
     auto* pgmm = PGGlobals::getPGMM();
-    const long itemCount = m_listCtrl->GetItemCount();
-    for (long i = 0; i < itemCount; ++i) {
-        const std::wstring modName = m_listCtrl->GetItemText(i, 0).ToStdWstring();
-        auto mod = pgmm->getMod(modName);
+    const int itemCount = static_cast<int>(orderedRows.size());
+    for (int i = 0; i < itemCount; ++i) {
+        const auto& row = *orderedRows.at(static_cast<size_t>(i));
+        auto mod = pgmm->getMod(row.modName);
         if (mod == nullptr) {
             continue;
         }
 
-        mod->isEnabled = m_listCtrl->isChecked(i);
+        mod->isEnabled = row.isChecked;
 
         if (mod->isEnabled) {
             mod->priority = static_cast<int>(itemCount - i);
         }
 
-        mod->areMeshesIgnored = m_listCtrl->areMeshesIgnored(i);
+        mod->areMeshesIgnored = row.areMeshesIgnored;
     }
 
     // save configs
@@ -500,12 +578,23 @@ void ModSortDialog::fillListCtrl(const std::vector<std::shared_ptr<PGModManager:
     std::unordered_set<std::wstring> currentlyCheckedMods;
     std::unordered_set<std::wstring> currentlyIgnoredMeshMods;
     if (preserveChecks) {
-        for (long i = 0; i < m_listCtrl->GetItemCount(); ++i) {
-            if (m_listCtrl->isChecked(i)) {
-                currentlyCheckedMods.insert(m_listCtrl->GetItemText(i).ToStdWstring());
+        if (!m_cachedRows.empty()) {
+            for (const auto& row : m_cachedRows) {
+                if (row.isChecked) {
+                    currentlyCheckedMods.insert(row.modName);
+                }
+                if (row.areMeshesIgnored) {
+                    currentlyIgnoredMeshMods.insert(row.modName);
+                }
             }
-            if (m_listCtrl->areMeshesIgnored(i)) {
-                currentlyIgnoredMeshMods.insert(m_listCtrl->GetItemText(i).ToStdWstring());
+        } else {
+            for (long i = 0; i < m_listCtrl->GetItemCount(); ++i) {
+                if (m_listCtrl->isChecked(i)) {
+                    currentlyCheckedMods.insert(m_listCtrl->GetItemText(i).ToStdWstring());
+                }
+                if (m_listCtrl->areMeshesIgnored(i)) {
+                    currentlyIgnoredMeshMods.insert(m_listCtrl->GetItemText(i).ToStdWstring());
+                }
             }
         }
     }
@@ -623,22 +712,244 @@ void ModSortDialog::fillListCtrl(const std::vector<std::shared_ptr<PGModManager:
     updateApplyButtonState();
 }
 
+void ModSortDialog::rebuildCacheFromListCtrl()
+{
+    m_cachedRows.clear();
+    m_cachedRows.reserve(static_cast<size_t>(m_listCtrl->GetItemCount()));
+
+    for (long i = 0; i < m_listCtrl->GetItemCount(); ++i) {
+        const std::wstring modName = m_listCtrl->GetItemText(i, 0).ToStdWstring();
+        m_cachedRows.push_back({.modName = modName,
+                                .shaderString = m_listCtrl->GetItemText(i, 1),
+                                .isChecked = m_listCtrl->isChecked(i),
+                                .areMeshesIgnored = m_listCtrl->areMeshesIgnored(i),
+                                .isNew = m_newMods.contains(modName)});
+    }
+}
+
+void ModSortDialog::syncCacheFromListCtrl()
+{
+    if (m_cachedRows.empty()) {
+        rebuildCacheFromListCtrl();
+        return;
+    }
+
+    std::vector<std::wstring> visibleOrder;
+    visibleOrder.reserve(m_listCtrl->GetItemCount());
+
+    std::unordered_set<std::wstring> visibleSet;
+    visibleSet.reserve(m_listCtrl->GetItemCount());
+
+    std::unordered_map<std::wstring, CachedModRow> visibleState;
+    visibleState.reserve(m_listCtrl->GetItemCount());
+
+    for (long i = 0; i < m_listCtrl->GetItemCount(); ++i) {
+        const std::wstring modName = m_listCtrl->GetItemText(i, 0).ToStdWstring();
+        visibleOrder.push_back(modName);
+        visibleSet.insert(modName);
+
+        visibleState[modName] = {.modName = modName,
+                                 .shaderString = m_listCtrl->GetItemText(i, 1),
+                                 .isChecked = m_listCtrl->isChecked(i),
+                                 .areMeshesIgnored = m_listCtrl->areMeshesIgnored(i),
+                                 .isNew = m_newMods.contains(modName)};
+    }
+
+    // First, merge visible row state.
+    for (auto& row : m_cachedRows) {
+        if (!visibleState.contains(row.modName)) {
+            continue;
+        }
+
+        const auto& visibleRow = visibleState.at(row.modName);
+        row.shaderString = visibleRow.shaderString;
+        row.isChecked = visibleRow.isChecked;
+        row.areMeshesIgnored = visibleRow.areMeshesIgnored;
+        row.isNew = visibleRow.isNew;
+    }
+
+    if (visibleOrder.size() == m_cachedRows.size()) {
+        // Unfiltered mode: list control is authoritative for full order.
+        std::unordered_map<std::wstring, CachedModRow> rowMap;
+        rowMap.reserve(m_cachedRows.size());
+        for (const auto& row : m_cachedRows) {
+            rowMap[row.modName] = row;
+        }
+
+        std::vector<CachedModRow> newOrder;
+        newOrder.reserve(m_cachedRows.size());
+        for (const auto& modName : visibleOrder) {
+            if (rowMap.contains(modName)) {
+                newOrder.push_back(rowMap.at(modName));
+            }
+        }
+
+        m_cachedRows = std::move(newOrder);
+        return;
+    }
+
+    // Filtered mode: only reorder visible subset while preserving hidden relative order.
+    std::unordered_map<std::wstring, CachedModRow> rowMap;
+    rowMap.reserve(m_cachedRows.size());
+    for (const auto& row : m_cachedRows) {
+        rowMap[row.modName] = row;
+    }
+
+    size_t insertPos = m_cachedRows.size();
+    for (size_t i = 0; i < m_cachedRows.size(); ++i) {
+        if (visibleSet.contains(m_cachedRows.at(i).modName)) {
+            insertPos = i;
+            break;
+        }
+    }
+
+    std::erase_if(m_cachedRows,
+                  [&visibleSet](const CachedModRow& row) -> bool { return visibleSet.contains(row.modName); });
+
+    insertPos = std::min(insertPos, m_cachedRows.size());
+
+    std::vector<CachedModRow> visibleRows;
+    visibleRows.reserve(visibleOrder.size());
+    for (const auto& modName : visibleOrder) {
+        if (rowMap.contains(modName)) {
+            visibleRows.push_back(rowMap.at(modName));
+        }
+    }
+
+    m_cachedRows.insert(m_cachedRows.begin() + static_cast<std::vector<CachedModRow>::difference_type>(insertPos),
+                        visibleRows.begin(),
+                        visibleRows.end());
+}
+
+void ModSortDialog::rebuildListCtrlFromCache()
+{
+    const wxString searchTerm = getActiveSearchTerm();
+
+    std::vector<const CachedModRow*> filteredRows;
+    filteredRows.reserve(m_cachedRows.size());
+
+    for (const auto& row : m_cachedRows) {
+        if (searchTerm.IsEmpty()) {
+            filteredRows.push_back(&row);
+            continue;
+        }
+
+        const wxString modName = wxString(row.modName).Lower();
+        if (modName.Contains(searchTerm)) {
+            filteredRows.push_back(&row);
+        }
+    }
+
+    std::vector<const CachedModRow*> activeRows;
+    std::vector<const CachedModRow*> inactiveRows;
+    activeRows.reserve(filteredRows.size());
+    inactiveRows.reserve(filteredRows.size());
+
+    for (const auto* row : filteredRows) {
+        if (row->isChecked) {
+            activeRows.push_back(row);
+        } else {
+            inactiveRows.push_back(row);
+        }
+    }
+
+    bool disableIsNew = true;
+    for (const auto* row : filteredRows) {
+        if (!row->isNew) {
+            disableIsNew = false;
+            break;
+        }
+    }
+
+    m_newMods.clear();
+    m_listCtrl->DeleteAllItems();
+
+    long index = 0;
+    for (const auto* row : activeRows) {
+        const long insertedIndex = m_listCtrl->InsertItem(index, row->modName);
+        m_listCtrl->SetItem(insertedIndex, 1, row->shaderString);
+        m_listCtrl->check(insertedIndex, true);
+        m_listCtrl->ignoreMeshes(insertedIndex, row->areMeshesIgnored);
+
+        if (!disableIsNew && row->isNew) {
+            m_listCtrl->SetItemBackgroundColour(insertedIndex, s_NEW_MOD_COLOR);
+            m_listCtrl->SetItemTextColour(insertedIndex, *wxBLACK);
+            m_newMods.insert(row->modName);
+        }
+
+        ++index;
+    }
+
+    m_listCtrl->setCutoffLine(static_cast<int>(activeRows.size()));
+
+    for (const auto* row : inactiveRows) {
+        const long insertedIndex = m_listCtrl->InsertItem(index, row->modName);
+        m_listCtrl->SetItem(insertedIndex, 1, row->shaderString);
+        m_listCtrl->check(insertedIndex, false);
+        m_listCtrl->ignoreMeshes(insertedIndex, row->areMeshesIgnored);
+
+        if (!disableIsNew && row->isNew) {
+            m_listCtrl->SetItemBackgroundColour(insertedIndex, s_NEW_MOD_COLOR);
+            m_listCtrl->SetItemTextColour(insertedIndex, *wxBLACK);
+            m_newMods.insert(row->modName);
+        }
+
+        ++index;
+    }
+
+    const bool mo2Locked = m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked();
+    if (m_restoreButton != nullptr) {
+        m_restoreButton->Enable(!mo2Locked);
+    }
+
+    m_listCtrl->setDraggingEnabled(!mo2Locked && searchTerm.IsEmpty());
+}
+
+auto ModSortDialog::getActiveSearchTerm() const -> wxString
+{
+    if (m_searchCtrl == nullptr) {
+        return {};
+    }
+
+    wxString term = m_searchCtrl->GetValue();
+    term.Trim(true);
+    term.Trim(false);
+    return term.Lower();
+}
+
 void ModSortDialog::updateApplyButtonState()
 {
+    syncCacheFromListCtrl();
+
     bool btnState = false;
 
-    // loop through each element in the list ctrl and update the mod manager directory
+    // Reconstruct full visual order: enabled rows first, disabled rows second, both stable by cached order.
+    std::vector<const CachedModRow*> orderedRows;
+    orderedRows.reserve(m_cachedRows.size());
+
+    for (const auto& row : m_cachedRows) {
+        if (row.isChecked) {
+            orderedRows.push_back(&row);
+        }
+    }
+    for (const auto& row : m_cachedRows) {
+        if (!row.isChecked) {
+            orderedRows.push_back(&row);
+        }
+    }
+
+    // Compare cached UI state against PGModManager baseline.
     auto* pgmm = PGGlobals::getPGMM();
-    const long itemCount = m_listCtrl->GetItemCount();
-    for (long i = 0; i < itemCount; ++i) {
-        const std::wstring modName = m_listCtrl->GetItemText(i, 0).ToStdWstring();
-        auto mod = pgmm->getMod(modName);
+    const int itemCount = static_cast<int>(orderedRows.size());
+    for (int i = 0; i < itemCount; ++i) {
+        const auto& row = *orderedRows.at(static_cast<size_t>(i));
+        auto mod = pgmm->getMod(row.modName);
         if (mod == nullptr) {
             btnState = true;
             break;
         }
 
-        if (mod->isEnabled != m_listCtrl->isChecked(i)) {
+        if (mod->isEnabled != row.isChecked) {
             btnState = true;
             break;
         }
@@ -648,7 +959,7 @@ void ModSortDialog::updateApplyButtonState()
             break;
         }
 
-        if (mod->areMeshesIgnored != m_listCtrl->areMeshesIgnored(i)) {
+        if (mod->areMeshesIgnored != row.areMeshesIgnored) {
             btnState = true;
             break;
         }

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -269,10 +269,23 @@ void ModSortDialog::onItemChecked(PGCheckedDragListCtrlEvtItemChecked& event)
         // Persist the just-updated visible check/ignore state before we rebuild from MO2 order.
         syncCacheFromListCtrl();
 
+        // Save scroll position before any list operations reset it, then wrap the entire
+        // rebuild sequence in a single Freeze/Thaw so the intermediate full-list state
+        // (from fillListCtrl inside setMO2LooseFileOrderCheckboxState) is never painted.
+        const long topItem = m_listCtrl->GetTopItem();
+        m_listCtrl->Freeze();
+
         // reset indices to MO2 state for enabled items
         setMO2LooseFileOrderCheckboxState();
         rebuildCacheFromListCtrl();
         rebuildListCtrlFromCache();
+
+        m_listCtrl->Thaw();
+
+        if (topItem > 0 && topItem < m_listCtrl->GetItemCount()) {
+            m_listCtrl->EnsureVisible(m_listCtrl->GetItemCount() - 1);
+            m_listCtrl->EnsureVisible(topItem);
+        }
     } else {
         syncCacheFromListCtrl();
     }
@@ -597,6 +610,7 @@ void ModSortDialog::fillListCtrl(const std::vector<std::shared_ptr<PGModManager:
     }
 
     m_newMods.clear();
+    m_listCtrl->Freeze();
     m_listCtrl->DeleteAllItems();
 
     std::vector<std::shared_ptr<PGModManager::Mod>> disabledMods;
@@ -696,6 +710,8 @@ void ModSortDialog::fillListCtrl(const std::vector<std::shared_ptr<PGModManager:
         // iterate listIdx
         listIdx++;
     }
+
+    m_listCtrl->Thaw();
 
     updateApplyButtonState();
 }
@@ -814,7 +830,7 @@ void ModSortDialog::rebuildListCtrlFromCache()
         }
     }
 
-    m_newMods.clear();
+    const long savedTopItem = m_listCtrl->GetTopItem();
     m_listCtrl->Freeze();
     m_listCtrl->DeleteAllItems();
 
@@ -852,6 +868,11 @@ void ModSortDialog::rebuildListCtrlFromCache()
     }
 
     m_listCtrl->Thaw();
+
+    if (savedTopItem > 0 && savedTopItem < m_listCtrl->GetItemCount()) {
+        m_listCtrl->EnsureVisible(m_listCtrl->GetItemCount() - 1);
+        m_listCtrl->EnsureVisible(savedTopItem);
+    }
 
     const bool mo2Locked = m_checkBoxMO2 != nullptr && m_checkBoxMO2->IsChecked();
     if (m_restoreButton != nullptr) {

--- a/PGPatcher/src/GUI/ModSortDialog.cpp
+++ b/PGPatcher/src/GUI/ModSortDialog.cpp
@@ -823,8 +823,8 @@ void ModSortDialog::rebuildListCtrlFromCache()
     }
 
     bool disableIsNew = true;
-    for (const auto* row : filteredRows) {
-        if (!row->isNew) {
+    for (const auto& row : m_cachedRows) {
+        if (!row.isNew) {
             disableIsNew = false;
             break;
         }

--- a/PGPatcher/src/GUI/components/PGCheckedDragListCtrl.cpp
+++ b/PGPatcher/src/GUI/components/PGCheckedDragListCtrl.cpp
@@ -478,6 +478,9 @@ void PGCheckedDragListCtrl::processCheckItems(const std::vector<long>& items,
         return;
     }
 
+    const long topItem = GetTopItem();
+    Freeze();
+
     std::vector<long> sortedItems = items;
 
     if (checked) {
@@ -491,6 +494,13 @@ void PGCheckedDragListCtrl::processCheckItems(const std::vector<long>& items,
     for (const long item : sortedItems) {
         processCheckItem(item, checked);
     }
+
+    Thaw();
+
+    if (topItem > 0 && topItem < GetItemCount()) {
+        EnsureVisible(GetItemCount() - 1);
+        EnsureVisible(topItem);
+    }
 }
 
 auto PGCheckedDragListCtrl::moveItem(long fromIndex,
@@ -499,6 +509,10 @@ auto PGCheckedDragListCtrl::moveItem(long fromIndex,
     if (fromIndex == toIndex || fromIndex < 0 || fromIndex >= GetItemCount()) {
         return fromIndex;
     }
+
+    const long topItem = GetTopItem(); // preserve scroll position across delete/insert
+
+    Freeze();
 
     // Capture item data (all columns)
     const int colCount = GetColumnCount();
@@ -529,6 +543,18 @@ auto PGCheckedDragListCtrl::moveItem(long fromIndex,
     SetItemBackgroundColour(newIndex, bgColor);
     check(newIndex, curChecked);
     ignoreMeshes(newIndex, curIgnoreMeshes);
+
+    Thaw();
+
+    // EnsureVisible while frozen is a no-op on the native Windows ListView (WM_SETREDRAW=FALSE).
+    // Call it AFTER Thaw. Thaw only posts InvalidateRect (deferred paint), not UpdateWindow,
+    // so EnsureVisible here runs before WM_PAINT fires - one clean repaint at the right position.
+    // Double-EnsureVisible: scroll to bottom first so the next call must scroll up,
+    // pinning topItem to the top of the viewport.
+    if (topItem > 0 && topItem < GetItemCount()) {
+        EnsureVisible(GetItemCount() - 1);
+        EnsureVisible(topItem);
+    }
 
     return newIndex;
 }

--- a/PGPatcher/src/GUI/components/PGCheckedDragListCtrl.cpp
+++ b/PGPatcher/src/GUI/components/PGCheckedDragListCtrl.cpp
@@ -2,6 +2,7 @@
 
 #include "GUI/components/PGCheckedDragListCtrlEvtItemChecked.hpp"
 #include "GUI/components/PGCheckedDragListCtrlEvtItemDragged.hpp"
+#include "GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp"
 #include "GUI/components/PGCheckedDragListCtrlGhostWindow.hpp"
 
 #include <wx/renderer.h>
@@ -423,6 +424,10 @@ void PGCheckedDragListCtrl::onContextMenu(wxContextMenuEvent& event)
             for (const long item : selectedItems) {
                 ignoreMeshes(item, false);
             }
+
+            PGCheckedDragListCtrlEvtMeshesIgnoredChanged evt(GetId());
+            evt.SetEventObject(this);
+            wxPostEvent(this, evt);
         },
         ID_ENABLE_MESHES);
 
@@ -433,6 +438,10 @@ void PGCheckedDragListCtrl::onContextMenu(wxContextMenuEvent& event)
             for (const long item : selectedItems) {
                 ignoreMeshes(item, true);
             }
+
+            PGCheckedDragListCtrlEvtMeshesIgnoredChanged evt(GetId());
+            evt.SetEventObject(this);
+            wxPostEvent(this, evt);
         },
         ID_DISABLE_MESHES);
 
@@ -511,9 +520,9 @@ auto PGCheckedDragListCtrl::moveItem(long fromIndex,
     }
 
     // Insert item at new position
-    const long newIndex = InsertItem(toIndex, cols.empty() ? wxString {} : cols[0]);
+    const long newIndex = InsertItem(toIndex, cols.empty() ? wxString {} : cols.at(0));
     for (int c = 1; c < colCount; ++c) {
-        SetItem(newIndex, c, cols[c]);
+        SetItem(newIndex, c, cols.at(static_cast<size_t>(c)));
     }
 
     // Restore properties
@@ -544,7 +553,7 @@ auto PGCheckedDragListCtrl::moveItems(const std::vector<long>& fromIndices,
     std::unordered_map<long, long> indexMap;
 
     for (size_t i = 0; i < sortedIndices.size(); i++) {
-        const long oldIndex = sortedIndices[i];
+        const long oldIndex = sortedIndices.at(i);
         long newIndex = toIndex;
 
         if (movingDown) {

--- a/PGPatcher/src/GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.cpp
+++ b/PGPatcher/src/GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.cpp
@@ -1,0 +1,14 @@
+#include "GUI/components/PGCheckedDragListCtrlEvtMeshesIgnoredChanged.hpp"
+
+// Disable owning memory checks because wxWidgets will take care of deleting the objects
+// Disable convert member functions to static because these functions need to be non-static for wxWidgets
+// NOLINTBEGIN(cppcoreguidelines-owning-memory,readability-convert-member-functions-to-static)
+
+wxDEFINE_EVENT(pgEVT_CDLC_MESHES_IGNORED_CHANGED,
+               PGCheckedDragListCtrlEvtMeshesIgnoredChanged);
+auto PGCheckedDragListCtrlEvtMeshesIgnoredChanged::Clone() const -> wxEvent*
+{
+    return new PGCheckedDragListCtrlEvtMeshesIgnoredChanged(*this);
+}
+
+// NOLINTEND(cppcoreguidelines-owning-memory,readability-convert-member-functions-to-static)


### PR DESCRIPTION
- [x] Understand codebase and plan changes
- [x] Fix `syncCacheFromListCtrl()` - don't overwrite `isNew` from `m_newMods`
- [x] Fix MO2 lock behavior during search - remove `getActiveSearchTerm().IsEmpty()` guard
- [x] Extract `orderedRows` building into `getOrderedCachedRows()` helper method
- [x] Fix `syncCacheFromListCtrl()` filtered-mode reorder displacing hidden rows (comment 3036333599)
- [x] Wrap `rebuildListCtrlFromCache()` rebuild in Freeze/Thaw to eliminate per-keystroke redraw churn (comment 3036333606)