### PR TITLE
Fix multithreaded exception hang and broken --no-multithreading flag

### DIFF
--- a/PGLib/src/util/TaskPoolRunner.cpp
+++ b/PGLib/src/util/TaskPoolRunner.cpp
@@ -91,9 +91,15 @@ void TaskPoolRunner::runTasks()
             break;
         }
 
-        // If exception stop thread pool and throw
+        // If exception stop thread pool and throw. stop() only prevents NOT-YET-STARTED tasks from
+        // running -- it does not (and cannot) retroactively mark them as completed, so
+        // m_completedTasks can never reach m_tasks.size() once even one task is abandoned this way.
+        // Without the break below, any exception thrown anywhere in a multithreaded run turns a
+        // real, reportable error into a silent, permanent hang instead: the caller waiting on this
+        // function never gets a chance to run, since the loop never returns.
         if (ExceptionHandler::hasException()) {
             m_threadPool.stop();
+            break;
         }
 
         // Sleep in between loops

--- a/PGTools/src/main.cpp
+++ b/PGTools/src/main.cpp
@@ -280,7 +280,12 @@ void addArguments(CLI::App& app,
                  args.verbosity,
                  "Verbosity level -v for DEBUG data or -vv for TRACE data "
                  "(warning: TRACE data is very verbose)");
-    app.add_flag("--no-multithreading", args.multithreading, "Disable multithreading");
+    // CLI11's add_flag on a bool just sets the bound variable to true whenever the flag is present --
+    // it does not infer "disable" semantics from the flag's own name. Since args.multithreading
+    // already defaults to true, passing --no-multithreading was a complete no-op. The `{false}`
+    // suffix is CLI11's own syntax for "set to this value when the flag is passed" -- this is what
+    // actually wires --no-multithreading to its own stated meaning.
+    app.add_flag("--no-multithreading{false}", args.multithreading, "Disable multithreading");
     app.add_flag("--shortcut",
                  args.shortcut,
                  "Keep pgtools running at the end (useful if you are running not in a terminal directly)");


### PR DESCRIPTION
## Summary

Two small, independent fixes found while debugging an apparent hang in `pgtools patch` on a large real-world install.

**1. `TaskPoolRunner::runTasks()` hangs forever on any exception under multithreading.**

When a task throws, the current code calls `m_threadPool.stop()` but keeps looping, waiting for `m_completedTasks` to reach `m_tasks.size()`. `stop()` only prevents not-yet-started tasks from running — it can't retroactively mark them complete, so that count can never be reached once even one task is abandoned this way. The result: any real exception thrown anywhere during a multithreaded `patchMeshes()`/`patchTextures()` run silently becomes a permanent hang instead of the clean, reportable error the single-threaded path already produces correctly.

Confirmed with a debugger (`cdb -p <pid> -pv -c "~*kb;qd"`) — the main thread was stuck in this exact polling loop (`TaskPoolRunner::runTasks` → `sleep_for`) while a genuine `std::filesystem` exception (an overlong output path, in my case) had already been recorded by `ExceptionHandler`.

Fix: `break` right after `stop()`.

**2. `--no-multithreading` never actually worked.**

`app.add_flag("--no-multithreading", args.multithreading, ...)` — CLI11's `add_flag` on a `bool` just sets the bound variable to `true` whenever the flag is present; it doesn't infer "disable" semantics from the flag's own name. Since `args.multithreading` already defaults to `true`, passing `--no-multithreading` was a complete no-op the entire time this flag has existed. Confirmed the same way — a "single-threaded" repro was still running the full multithreaded `TaskPoolRunner` path under a debugger.

Fix: use CLI11's own `{false}` flag-value syntax (`--no-multithreading{false}`), which sets the value to `false` specifically when the flag is passed.

## Context

Both bugs are real and independent of what actually caused my own hang (a plain filesystem exception from an overlong output path on my end, nothing PGPatcher-side) — but that investigation is what surfaced bug #1, and bug #2 is what made single-threaded testing silently misleading while tracking it down.

## Test plan

- [x] Rebuilt `pgtools` with both fixes.
- [x] Reproduced the original hang scenario (exception under multithreading) — now fails fast and cleanly instead of hanging.
- [x] Confirmed `--no-multithreading{false}` genuinely runs single-threaded (verified via debugger stack trace showing the synchronous code path, and via wall-clock timing).
- [x] Full real `pgtools patch` run (multithreaded, real texture patching, ~2000-mod install, normal-length output path) completed successfully in 197 seconds with these fixes applied.